### PR TITLE
use home folder of current user

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,6 +1,7 @@
 #include "config.h"
 
 #include <QSettings>
+#include <QStandardPaths>
 
 QSettings sets("cepiperez", "fileboxplus");
 
@@ -29,5 +30,5 @@ void Config::removeConfig(QString data1)
 
 QString Config::getHome()
 {
-    return readConfig("PhoneMemoryFolder", "/home/defaultuser");
+    return QStandardPaths::standardLocations(QStandardPaths::HomeLocation).first();
 }


### PR DESCRIPTION
closes #15 

This should return the current users home directory instead of hard coding it.

https://doc.qt.io/qt-5/qstandardpaths.html

[`QDir::homePath](https://doc.qt.io/qt-5/qdir.html#homePath) would be another alternative

(not actually tested)