### PR TITLE
[filecase.spec] Add `BuildRequires: pkgconfig(Qt5Xml)` to fix issue #54

### DIFF
--- a/rpm/filecase.spec
+++ b/rpm/filecase.spec
@@ -41,6 +41,7 @@ Source99:   %{name}.rpmlintrc
 Requires:   sailfishsilica-qt5 >= 0.10.9
 BuildRequires:  pkgconfig(sailfishapp) >= 1.0.2
 BuildRequires:  pkgconfig(Qt5Core)
+BuildRequires:  pkgconfig(Qt5Xml)
 BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(Qt5Quick)
 BuildRequires:  desktop-file-utils


### PR DESCRIPTION
[Contributed](https://github.com/sailfishos-applications/filecase/issues/54#issuecomment-1825535892) by @nephros