### PR TITLE
Fix WebDAV + Thumbnail + Open + Share + `port.text` + another fix

### DIFF
--- a/qml/pages/AddWebDavAccount.qml
+++ b/qml/pages/AddWebDavAccount.qml
@@ -65,7 +65,6 @@ Page {
                 width: parent.width
                 //placeholderText: qsTr("Service name")
                 label: qsTr("Service name")
-                _labelItem.opacity: 1
                 enabled: !working
                 focus: true
                 EnterKey.enabled: name.text.length>0
@@ -78,7 +77,6 @@ Page {
                 placeholderText: "webdav.service.com"
                 inputMethodHints: Qt.ImhNoAutoUppercase
                 label: qsTr("Server")
-                _labelItem.opacity: 1
                 enabled: !working
                 EnterKey.enabled: host.text.length>0
                 EnterKey.onClicked: path.forceActiveFocus()
@@ -90,7 +88,6 @@ Page {
                 placeholderText: "/"
                 text: "/"
                 label: qsTr("Path")
-                _labelItem.opacity: 1
                 enabled: !working
                 EnterKey.enabled: path.text.length>0
                 EnterKey.onClicked: port.forceActiveFocus()
@@ -102,7 +99,6 @@ Page {
                 placeholderText: host.text.indexOf("http://")>-1? "80" : "443"
                 text: host.text.indexOf("http://")>-1? "80" : "443"
                 label: qsTr("Port")
-                _labelItem.opacity: 1
                 inputMethodHints: Qt.ImhDigitsOnly
                 enabled: !working
                 EnterKey.enabled: port.text.length>0
@@ -114,7 +110,6 @@ Page {
                 width: parent.width
                 //placeholderText: qsTr("User")
                 label: qsTr("User")
-                _labelItem.opacity: 1
                 inputMethodHints: Qt.ImhNoAutoUppercase
                 enabled: !working
                 EnterKey.enabled: user.text.length>0
@@ -125,8 +120,7 @@ Page {
                 id: pass
                 width: parent.width
                 //placeholderText: qsTr("Password")
-                label: qsTr("Password")
-                _labelItem.opacity: 1
+                label: qsTr("Password")  
                 enabled: !working
                 echoMode: TextInput.Password
                 inputMethodHints: Qt.ImhNoAutoUppercase
@@ -146,7 +140,7 @@ Page {
                 enabled: !working && name.text.length>0 && host.text.length>0 && path.text.length>0 && user.text.length>0 && pass.text.length>0
                 onClicked: {
                     working = true
-                    webdav.createAccount(name.text, host.text, path.text, user.text, pass.text)
+                    webdav.createAccount(name.text, host.text, path.text, user.text, pass.text, port.text)
                 }
             }
 

--- a/qml/pages/AddWebDavAccount.qml
+++ b/qml/pages/AddWebDavAccount.qml
@@ -120,7 +120,7 @@ Page {
                 id: pass
                 width: parent.width
                 //placeholderText: qsTr("Password")
-                label: qsTr("Password")  
+                label: qsTr("Password")
                 enabled: !working
                 echoMode: TextInput.Password
                 inputMethodHints: Qt.ImhNoAutoUppercase

--- a/qml/pages/FileDelegate.qml
+++ b/qml/pages/FileDelegate.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.0
 import Sailfish.Silica 1.0
 import FileCase 1.0
-import org.nemomobile.thumbnailer 1.0
+import Nemo.Thumbnailer 1.0
 
 ListItem {
 

--- a/qml/pages/FileInfo.qml
+++ b/qml/pages/FileInfo.qml
@@ -1,8 +1,8 @@
 import QtQuick 2.0
 import Sailfish.Silica 1.0
 import FileCase 1.0
-import org.nemomobile.thumbnailer 1.0
 import QtMultimedia 5.0
+import Nemo.Thumbnailer 1.0
 
 Page {
     id: infoPage
@@ -108,7 +108,7 @@ Page {
             MenuItem {
                 text: isPackage && !cloudFile? qsTr("Install") : qsTr("Open")
                 visible: !cloudFile && !isTextFile
-                onClicked: utilities.openFile(fileInfo.data.path + "/" + fileInfo.data.name)
+                onClicked: Qt.openUrlExternally(fileInfo.data.path + "/" + fileInfo.data.name)
             }
 
             MenuItem {

--- a/qml/pages/UploadFiles.qml
+++ b/qml/pages/UploadFiles.qml
@@ -2,7 +2,7 @@ import QtQuick 2.0
 import Sailfish.Silica 1.0
 import FileCase 1.0
 import QtMultimedia 5.0
-import Sailfish.TransferEngine 1.0
+import Sailfish.Share 1.0
 
 Page {
 
@@ -20,10 +20,15 @@ Page {
         pageStack.pop()
     }
 
-    SailfishTransferMethodsModel {
-        id: transferMethodsModel
-    //  filter: fileInfo.data.mime  // Debatable, if no filter is better, as it allows for all files
+
+    ShareAction {
+        id: shareAction
     }
+
+//    SailfishTransferMethodsModel {
+//        id: transferMethodsModel
+//    //  filter: fileInfo.data.mime  // Debatable, if no filter is better, as it allows for all files
+//    }
 
     ListModel {
         id: emptyModel
@@ -72,13 +77,16 @@ Page {
                 }
             }
 
+
+
             Repeater {
                 id: rootList
                 property url source: fileInfo.data.path + "/" + fileInfo.data.name
                 property variant content: ({})
                 //property alias filter: transferMethodsModel.filter
 
-                model: fileInfo.data.icon!==""? transferMethodsModel : emptyModel
+//              model: fileInfo.data.icon!==""? transferMethodsModel : emptyModel
+                model: emptyModel
 
                 objectName: "menuList"
                 //source: fileInfo.path + "/" + fileInfo.name
@@ -90,15 +98,8 @@ Page {
                     title: qsTrId(displayName)
                     description: userName
                     onClicked: {
-                        clearSelectionItems()
-                        pageStack.replace(shareUIPath, {
-                                           source: rootList.source,
-                                           content: rootList.content,
-                                           methodId: methodId,
-                                           displayName: displayName,
-                                           accountId: accountId,
-                                           accountName: userName
-                                       })
+                        shareAction.fileUrls = [rootList.source]
+                        shareAction.share()
 
                     }
 

--- a/rpm/filecase.changes
+++ b/rpm/filecase.changes
@@ -1,3 +1,4 @@
+
 * Fri Nov 24 2023 olf <Olf0@users.noreply.github.com> - 0.4.3
 - Update Swedish translation (PR #47) by @eson57
 - Introduce a quick & dirty workaround for issue #15 (PR #46) by @simonschmeisser

--- a/rpm/filecase.changes
+++ b/rpm/filecase.changes
@@ -1,3 +1,8 @@
+* Fri Nov 24 2023 olf <amer@ma.tc> -  0.4.3-1
+- Fix QML rendering error in AddWebDavAccount
+- Fix Transfer View For Webdav Upload
+- Fix Webdav Upload
+
 * Thu Nov 16 2023 olf <Olf0@users.noreply.github.com> - 0.4.2
 - Update Swedish translation (PR #47) by @eson57
 - Introduce a quick & dirty workaround for issue #15 (PR #46) by @simonschmeisser

--- a/rpm/filecase.changes
+++ b/rpm/filecase.changes
@@ -1,4 +1,4 @@
-* Sat Nov 25 2023 Logic-gate <amer@ma.tc> - 0.4.4
+* Sat Nov 25 2023 Amer Almadani (Logic-gate) <amer@ma.tc> - 0.4.4
 - Fix QML rendering error in AddWebDavAccount
 - Fix Transfer View For Webdav Upload
 - Fix Webdav Upload

--- a/rpm/filecase.spec
+++ b/rpm/filecase.spec
@@ -10,7 +10,7 @@ Name:       filecase
 Summary:    An advanced file-manager for SailfishOS
 # The <version> tag must adhere to semantic versioning: Among multiple other
 # reasons due to its use for `qmake5` in line 107.  See https://semver.org/
-Version:    0.4.3.1
+Version:    0.4.4
 # The <release> tag comprises one of {alpha,beta,rc,release} postfixed with a
 # natural number greater or equal to 1 (e.g., "beta3") and may additionally be
 # postfixed with a plus character ("+"), the name of the packager and a release
@@ -21,7 +21,7 @@ Version:    0.4.3.1
 # build at GitHub and OBS, when configured accordingly; mind the sorting
 # (`adud` < `alpha`).  For details and reasons, see
 # https://github.com/storeman-developers/harbour-storeman/wiki/Git-tag-format
-Release:    rc4
+Release:    rc5
 # The Group tag should comprise one of the groups listed here:
 # https://github.com/mer-tools/spectacle/blob/master/data/GROUPS
 Group:      Applications/File

--- a/rpm/filecase.spec
+++ b/rpm/filecase.spec
@@ -10,7 +10,7 @@ Name:       filecase
 Summary:    An advanced file-manager for SailfishOS
 # The <version> tag must adhere to semantic versioning: Among multiple other
 # reasons due to its use for `qmake5` in line 107.  See https://semver.org/
-Version:    0.4.3
+Version:    0.4.3.1
 # The <release> tag comprises one of {alpha,beta,rc,release} postfixed with a
 # natural number greater or equal to 1 (e.g., "beta3") and may additionally be
 # postfixed with a plus character ("+"), the name of the packager and a release

--- a/src/transfers.cpp
+++ b/src/transfers.cpp
@@ -280,13 +280,18 @@ void Transfers::transferFile(QStringList file)
         }
 
 
+
+
         QStringList uploadPath = settings.value(file.at(0)+"/upload_folder","/||/").toString().split("||");
 
+//       qDebug() << "TEST POINT 3: " << uploadPath;
+
         currentFile = QFileInfo(file.at(3)).fileName();
-        currentFile = uploadPath[1] + "/" + currentFile;
+        currentFile = uploadPath[0] + "/" + currentFile; //List only has one element, hench changing to first. This is due to a change in UploadFiles.qml
         currentFile = currentFile.replace("https:/","https://");
         currentFile = currentFile.replace("//","/");
         uploadFile = new QFile(file.at(3));
+
 
         if(!uploadFile->open(QFile::ReadOnly))
         {
@@ -298,6 +303,9 @@ void Transfers::transferFile(QStringList file)
         emit workingChanged(working);
 
         QByteArray myFile = uploadFile->readAll();
+
+        qDebug() << "TEST POINT 9";
+
 
         if (file.at(0).startsWith("OneDrive"))
         {

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -76,6 +76,7 @@ void Utilities::removeFromBookmarks(QString folder)
 
 void Utilities::openFile(QString file)
 {
+    //This is no longer needed since we will be using Qt.openUrlExternally keeping it here untill final testing
     QProcess * process = new QProcess();
     process->start(QString("xdg-open \"%2\"").arg(file));
 

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -76,7 +76,7 @@ void Utilities::removeFromBookmarks(QString folder)
 
 void Utilities::openFile(QString file)
 {
-    //This is no longer needed since we will be using Qt.openUrlExternally keeping it here untill final testing
+    // This is no longer needed since we will be using Qt.openUrlExternally.  Keeping it here until final testing.
     QProcess * process = new QProcess();
     process->start(QString("xdg-open \"%2\"").arg(file));
 


### PR DESCRIPTION
First of all, thank you for guiding me through the intricacies of git 

These fixes include the following:

- Fix QML rendering error in `AddWebDavAccount` -- Removal of all `_labelItem.opacity: 1` and the addition of `port.text`

- Fix Transfer View For Webdav Upload -- This needs to be rechecked since I removed `Sailfish.TransferEngine` and used `Sailfish.Share` It works fine, but I am not sure if it's the intention of it, since it only shows cloud services. I'll retest with multiple webdav accounts later today. Looking at the original [share page screenshot](https://raw.githubusercontent.com/sailfishos-applications/filecase/devel/.xdata/screenshots/screenshot-007.jpg), it seems that it had Bluetooth share as well. I'll need to recheck this. The problem was that `SailfishTransferMethodsModel` was throwing an unknown component. I searched for the documentation, but couldn't find anything specific, hence I assumed it was a deprecated method.

- Fix Webdav Upload -- This entails the change in `src/transfers.cpp.` It was throwing a Segmentation Fault and fishing for the cause led me to simply select the first element in the list. I suspect it has to do with the changes in `UploadFiles.qml`

- Thumbnails 
  - Seems like the issue is twofold, for images, the `.thumbnails` dir is not created. Perhaps it should be done when installing.
  
  - For videos `/usr/lib/qt5/qml/org/nemomobile/thumbnailer/thumbnailers/libvideothumbnailer.so` is missing from my system. New implementation requires `ffmpeg` which I am assuming ships by default with sailfish. If not, then we'll have to re do it using the thumbnail lib. There's a quality factor within `ffmpeg`: see https://ffmpeg.org/ffmpeg-codecs.html#Options-22.  
 
 - Open fix: Replaced `Utilities::openFile`  which used `xdg-open` with `Qt.openUrlExternally`.
 
 I am still working on various fixes and clean ups. You can always check https://ghamama.openproject.com/projects/filecase/work_packages to see where I am and what I am doing

