### PR TITLE
Fix for code scanning alert no. 3: "Workflow does not contain permissions"

### DIFF
--- a/.github/workflows/build-on-pull_req.yml
+++ b/.github/workflows/build-on-pull_req.yml
@@ -1,4 +1,7 @@
 name: CI on PRs with SDK for 3.0.2 (i486)
+permissions:
+  contents: read
+  actions: write
 
 env:
   RELEASE: 3.0.2.8

--- a/.github/workflows/build-on-pull_req.yml
+++ b/.github/workflows/build-on-pull_req.yml
@@ -1,4 +1,5 @@
 name: CI on PRs with SDK for 3.0.2 (i486)
+
 permissions:
   contents: read
   actions: write


### PR DESCRIPTION
Fix for https://github.com/sailfishos-applications/filecase/security/code-scanning/3

To fix the issue, a permissions block is added at the root of the workflow file. This block defines the minimal permissions required for the workflow to function correctly. Based on the workflow's actions, it appears that it only needs to read repository contents and upload artefacts. Therefore, we will set contents: read and actions: write permissions.

The permissions block is added after the `name` field and before the `env` block to apply these permissions globally to all jobs in the workflow.