### PR TITLE
Fix for code scanning alert no. 2: "Workflow does not contain permissions"

### DIFF
--- a/.github/workflows/manual_template.yml
+++ b/.github/workflows/manual_template.yml
@@ -1,6 +1,9 @@
 # This is a basic workflow that is manually triggered
-
 name: Manual workflow
+
+permissions:
+  contents: read
+  actions: write
 
 # Controls when the action will run. Workflow runs when manually triggered using the UI
 # or API.


### PR DESCRIPTION
Fix for https://github.com/sailfishos-applications/filecase/security/code-scanning/2

To fix the issue, a permissions block is added at the root of the workflow file. This block defines the minimal permissions required for the workflow to function correctly. Here `contents: read` and `actions: write` permissions are set.

The permissions block is added right after the `name` field to apply these permissions globally to all jobs in the workflow.