### PR TITLE
Fix for code scanning alert no. 1: "Workflow does not contain permissions"

### DIFF
--- a/.github/workflows/build-on-tags.yml
+++ b/.github/workflows/build-on-tags.yml
@@ -1,5 +1,9 @@
 name: CI on tags (aarch64,armv7hl,i486)
 
+permissions:
+  contents: read
+  actions: write
+
 on:
   push:
     tags:


### PR DESCRIPTION
Fix for https://github.com/sailfishos-applications/filecase/security/code-scanning/1

To fix the issue, a permissions block is added at the root of the workflow file. This block defines the minimal permissions required for the workflow to function correctly. Based on the workflow's actions, it appears that it only needs to read repository contents and upload artefacts. Therefore, `contents: read` and `actions: write` permissions are set.

The permissions block is added right after the `name` field to apply these permissions globally to all jobs in the workflow.

-------

Signed-off-by: olf <Olf0@users.noreply.github.com>
