### PR TITLE
[filecase.pro] Reorder entries and list all files

### DIFF
--- a/filecase.pro
+++ b/filecase.pro
@@ -20,145 +20,157 @@ QT += core xml
 DEFINES += QWEBDAVITEM_EXTENDED_PROPERTIES DEBUG_WEBDAV
 DEFINES += VERSION=\\\"$${VERSION}\\\"
 
-SOURCES += src/filecase.cpp \
+SOURCES += \
+    src/boxclient.cpp \
+    src/boxthumbnailer.cpp \
     src/browser.cpp \
-    src/config.cpp \
-    src/qtfilecopier.cpp \
-    src/utils.cpp \
-    src/filedeleter.cpp \
-    src/fileinfo.cpp \
-    src/loader.cpp \
-    src/thumbgenerator.cpp \
     src/clipboard.cpp \
-    src/search.cpp \
+    src/compressedfiles.cpp \
+    src/config.cpp \
+    src/drive/json.cpp \
+    src/drive/jsonparser.cpp \
     src/driveclient.cpp \
     src/drivethumbnailer.cpp \
-    src/drive/jsonparser.cpp \
-    src/drive/json.cpp \
-    src/dropboxclient.cpp \
-    src/dropboxthumbnailer.cpp \
     src/dropbox/common.cpp \
     src/dropbox/consumerdata.cpp \
     src/dropbox/dropbox.cpp \
     src/dropbox/dropoauth.cpp \
+    src/dropbox/qt-json/json.cpp \
     src/dropbox/userdata.cpp \
     src/dropbox/util.cpp \
-    src/skyclient.cpp \
-    src/skythumbnailer.cpp \
-    src/compressedfiles.cpp \
-    src/utilities.cpp \
-    src/webdav.cpp \
+    src/dropboxclient.cpp \
+    src/dropboxthumbnailer.cpp \
+    src/filecase.cpp \
+    src/filedeleter.cpp \
+    src/fileinfo.cpp \
+    src/loader.cpp \
+    src/megacli.cpp \
+    src/qtfilecopier.cpp \
     src/qwebdavlib/qnaturalsort.cpp \
     src/qwebdavlib/qwebdav.cpp \
     src/qwebdavlib/qwebdavdirparser.cpp \
     src/qwebdavlib/qwebdavitem.cpp \
+    src/search.cpp \
+    src/skyclient.cpp \
+    src/skythumbnailer.cpp \
+    src/thumbgenerator.cpp \
     src/transfers.cpp \
-    src/boxclient.cpp \
-    src/boxthumbnailer.cpp
+    src/utilities.cpp \
+    src/utils.cpp \
+    src/webdav.cpp
 
-OTHER_FILES += qml/filecase.qml \
+OTHER_FILES += \
     rpm/filecase.spec \
-    rpm/filecase.yaml \
+    rpm/filecase.changes \
+    rpm/filecase.rpmlintrc \
     translations/*.ts \
     filecase.desktop \
-    qml/pages/MainPage.qml \
-    qml/pages/CoverPage.qml \
-    qml/pages/MyHeader.qml \
-    qml/pages/Settings.qml \
-    qml/pages/FileInfo.qml \
-    qml/pages/ValueItem.qml \
-    qml/pages/RenameFile.qml \
-    qml/pages/ClipboardPage.qml \
-    qml/pages/Banner.qml \
-    qml/pages/NewFolder.qml \
-    qml/pages/FoldersPanel.qml \
-    qml/pages/FileDelegate.qml \
-    qml/pages/FolderDelegate.qml \
-    qml/pages/SelectLanguage.qml \
-    qml/pages/SearchPage.qml \
-    qml/pages/Drive.qml \
-    qml/pages/DriveSettings.qml \
-    qml/pages/DriveUploadFolder.qml \
-    qml/pages/TransfersDelegate.qml \
-    qml/pages/SelDownloadFolder.qml \
-    qml/pages/UploadFiles.qml \
-    qml/pages/Dropbox.qml \
-    qml/pages/DropboxSettings.qml \
-    qml/pages/DropboxUploadFolder.qml \
-    qml/pages/SkyDrive.qml \
-    qml/pages/SkySettings.qml \
-    qml/pages/SkyUploadFolder.qml \
-    qml/pages/TransfersPage.qml \
-    qml/pages/ButtonHeader.qml \
-    qml/pages/Compressed.qml \
-    qml/pages/ExtractDialog.qml \
-    qml/pages/CompressDialog.qml \
-    qml/pages/WebDavPage.qml \
-    qml/pages/WebDavSettings.qml \
-    qml/pages/WebDavUploadFolder.qml \
-    qml/pages/AddWebDavAccount.qml \
+    qml/filecase.qml \
+    qml/pages/AboutPage.qml \
     qml/pages/AddAccount.qml \
+    qml/pages/AddWebDavAccount.qml \
+    qml/pages/Banner.qml \
     qml/pages/Box.qml \
     qml/pages/BoxSettings.qml \
     qml/pages/BoxUploadFolder.qml \
-    rpm/filecase.changes \
-    qml/pages/TextViewer.qml \
+    qml/pages/ButtonHeader.qml \
+    qml/pages/ClipboardPage.qml \
+    qml/pages/CompressDialog.qml \
+    qml/pages/Compressed.qml \
+    qml/pages/CoverPage.qml \
+    qml/pages/Drive.qml \
+    qml/pages/DriveSettings.qml \
+    qml/pages/DriveTransfers.qml \
+    qml/pages/DriveUploadFolder.qml \
+    qml/pages/Dropbox.qml \
+    qml/pages/DropboxSettings.qml \
+    qml/pages/DropboxTransfers.qml \
+    qml/pages/DropboxUploadFolder.qml \
+    qml/pages/ExtractDialog.qml \
+    qml/pages/FileDelegate.qml \
+    qml/pages/FileInfo.qml \
+    qml/pages/FolderDelegate.qml \
+    qml/pages/FoldersPanel.qml \
+    qml/pages/MainPage.qml \
+    qml/pages/MyHeader.qml \
+    qml/pages/NewFolder.qml \
+    qml/pages/RenameFile.qml \
+    qml/pages/SearchPage.qml \
+    qml/pages/SelDownloadFolder.qml \
+    qml/pages/SelectLanguage.qml \
+    qml/pages/Settings.qml \
+    qml/pages/SkyDrive.qml \
+    qml/pages/SkySettings.qml \
+    qml/pages/SkyTransfers.qml \
+    qml/pages/SkyUploadFolder.qml \
     qml/pages/TextEditor.qml \
-    qml/pages/AboutPage.qml
+    qml/pages/TextViewer.qml \
+    qml/pages/TransfersDelegate.qml \
+    qml/pages/TransfersPage.qml \
+    qml/pages/UploadFiles.qml \
+    qml/pages/ValueItem.qml \
+    qml/pages/WebDavPage.qml \
+    qml/pages/WebDavSettings.qml \
+    qml/pages/WebDavUploadFolder.qml
 
-# to disable building translations every time, comment out the
-# following CONFIG line
+# to disable building translations every time,
+# comment out the following CONFIG line
 CONFIG += sailfishapp_i18n
-TRANSLATIONS += translations/ca.ts \
-                translations/de.ts \
-                translations/es.ts \
-                translations/fa.ts \
-                translations/fi.ts \
-                translations/fr.ts \
-                translations/it.ts \
-                translations/nl.ts \
-                translations/ru.ts \
-                translations/sv.ts \
-                translations/zh.ts \
-                translations/zh_HK.ts \
-                translations/zh_TW.ts
+TRANSLATIONS += \
+    translations/ca.ts \
+    translations/de.ts \
+    translations/es.ts \
+    translations/et.ts \
+    translations/fa.ts \
+    translations/fi.ts \
+    translations/fr.ts \
+    translations/it.ts \
+    translations/nl.ts \
+    ### translations/pl.ts \ ###
+    translations/ru.ts \
+    translations/sv.ts \
+    translations/zh.ts \
+    translations/zh_HK.ts \
+    translations/zh_TW.ts
 
 HEADERS += \
+    src/boxclient.h \
+    src/boxthumbnailer.h \
     src/browser.h \
-    src/config.h \
-    src/qtfilecopier.h \
-    src/utils.h \
-    src/filedeleter.h \
-    src/fileinfo.h \
-    src/loader.h \
-    src/thumbgenerator.h \
     src/clipboard.h \
-    src/search.h \
+    src/compressedfiles.h \
+    src/config.h \
+    src/drive/json.h \
+    src/drive/jsonparser.h \
     src/driveclient.h \
     src/drivethumbnailer.h \
-    src/drive/jsonparser.h \
-    src/drive/json.h \
-    src/dropboxclient.h \
-    src/dropboxthumbnailer.h \
     src/dropbox/common.h \
     src/dropbox/consumerdata.h \
     src/dropbox/dropbox.h \
     src/dropbox/dropoauth.h \
+    src/dropbox/qt-json/json.h \
     src/dropbox/userdata.h \
     src/dropbox/util.h \
-    src/skyclient.h \
-    src/skythumbnailer.h \
-    src/compressedfiles.h \
-    src/utilities.h \
-    src/webdav.h \
+    src/dropboxclient.h \
+    src/dropboxthumbnailer.h \
+    src/filedeleter.h \
+    src/fileinfo.h \
+    src/loader.h \
+    src/megacli.h \
+    src/qtfilecopier.h \
     src/qwebdavlib/qnaturalsort.h \
     src/qwebdavlib/qwebdav.h \
     src/qwebdavlib/qwebdav_global.h \
     src/qwebdavlib/qwebdavdirparser.h \
     src/qwebdavlib/qwebdavitem.h \
+    src/search.h \
+    src/skyclient.h \
+    src/skythumbnailer.h \
+    src/thumbgenerator.h \
     src/transfers.h \
-    src/boxclient.h \
-    src/boxthumbnailer.h
+    src/utilities.h \
+    src/utils.h \
+    src/webdav.h
 
 icons.files = icons
 icons.path = /usr/share/$$TARGET


### PR DESCRIPTION
- All `.cpp` files in `src/` and subdirectories for the category `SOURCES`: 2 new entries
- All `.qml` files in `qml/` and subdirectories for the category `OTHER_FILES`, plus a few more: 3 new entries
- All `.ts` files in `translations/` for the category `TRANSLATIONS`:
  1,5 new entries, Estonian (`et`) and added a commented-out Polish (`pl`) entry, because a translation was promised. 
- All `.h` files in `src/` and subdirectories for the category `HEADERS`: 2 new entries

---------

Signed-off-by: olf <Olf0@users.noreply.github.com>
